### PR TITLE
Order of the posts

### DIFF
--- a/simple.py
+++ b/simple.py
@@ -53,6 +53,8 @@ def index():
     posts = posts_master.limit(app.config["POSTS_PER_PAGE"]).offset(page*app.config["POSTS_PER_PAGE"]).all()
     is_more = posts_count > ((page*app.config["POSTS_PER_PAGE"]) + app.config["POSTS_PER_PAGE"])
 
+    posts.reverse()
+    
     return render_template("index.html", posts=posts, now=datetime.datetime.now(),
                                          is_more=is_more, current_page=page)
 


### PR DESCRIPTION
Hey,

Found another small details interesting enough to report. I played with simple and it's very nice. A very nice work.

**The issue:**

I don't know if this is like that on purpose but a blog usually displays it's posts in reverse order, i.e., the newer posts will be displayed first.

Maybe you forgot this, maybe it's the way you want it.

Anyway, a simple 

```
posts.reverse()
```

fixes it...
