### PR TITLE
Fix BuildError on creating a new post and saving

### DIFF
--- a/simple.py
+++ b/simple.py
@@ -143,7 +143,7 @@ def new_post():
     db.session.add(post)
     db.session.commit()
 
-    return redirect(url_for("edit", id=post.id))
+    return redirect(url_for("edit", post_id=post.id))
 
 @app.route("/edit/<int:post_id>", methods=["GET","POST"])
 @requires_authentication
@@ -170,7 +170,7 @@ def edit(post_id):
 
         db.session.add(post)
         db.session.commit()
-        return redirect(url_for("edit", id=post_id))
+        return redirect(url_for("edit", post_id=post_id))
 
 @app.route("/delete/<int:post_id>", methods=["GET","POST"])
 @requires_authentication


### PR DESCRIPTION
It seems a parameter name was changed from id to post_id,
but two places where 'id' occurred were missed. This commit
fixes a BuildError / 500 internal server error on creating a new
post and on saving a post.
