### PR TITLE
update: blog title can't contain single quotes

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -30,8 +30,8 @@ ANALYTICS_ID = '%s'
 SQLALCHEMY_DATABASE_URI = "%s"
 GITHUB_USERNAME = '%s'
 CONTACT_EMAIL = '%s'
-BLOG_TITLE = '%s'
-BLOG_TAGLINE = '%s'
+BLOG_TITLE = "%s"
+BLOG_TAGLINE = "%s"
 BLOG_URL = '%s'\n""" % SETTINGS)
     fd.flush()
 


### PR DESCRIPTION
Hi I just make a small update on file create_config.py. 
Blog title and blog tagline was qoted using single quote, so it can not contains
text that containing single quuotes, for example: Another John's Blog.
Application will error, so I change it to double quote.

Thanks.
