### PR TITLE
delete urllib module

### DIFF
--- a/simple.py
+++ b/simple.py
@@ -3,7 +3,7 @@
 # python imports
 import re
 import datetime
-import os,urllib
+import os
 from functools import wraps
 from unicodedata import normalize
 


### PR DESCRIPTION
At first I use urllib.quote to encode Utf-8 strs, however I find that the Flask itself automatically encode the URLs. So a URL is encoded twice.

Then I delete the quote func,but I forget to delete the import
