### PR TITLE
Fixed index page to no longer show the 500 response code.

### DIFF
--- a/simple.py
+++ b/simple.py
@@ -128,7 +128,7 @@ def index():
 
     posts = posts_master\
         .limit(app.config["POSTS_PER_PAGE"])\
-        .offset(page * app.config["POSTS_PER_PAGE"]) .all()
+        .offset(page * int(app.config["POSTS_PER_PAGE"])) .all()
 
     # Sorry for the verbose names, but this seemed like a sensible
     # thing to do.


### PR DESCRIPTION
```
posts = posts_master\
    .limit(app.config["POSTS_PER_PAGE"])\
    .offset(page * app.config["POSTS_PER_PAGE"]) .all()
```

Line was causing the index page to return a 500 response code. Casted the app.config["POSTS_PER_PAGE"] to int to prevent this.
