### PR TITLE
change 404 error handling when post is not found.

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+
+{% block title %}<title>{{ config.BLOG_TITLE }}</title>{% endblock %}
+
+{% block content %}
+	<h1>Page Not Found</h1>
+	<p>What you were looking for is just not there.</p>
+	<p><a href="{{ url_for('index') }}">Return to the index</a></p>
+{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+
+{% block title %}<title>{{ config.BLOG_TITLE }}</title>{% endblock %}
+
+{% block content %}
+	<h1>Error on page</h1>
+	<p>There were an error on the page.</p>
+	<p><a href="{{ url_for('index') }}">Return to the index</a></p>
+{% endblock %}


### PR DESCRIPTION
Hi again,

Just a small proposition for your "better exception" comment: I changed the type of caught exceptions to sqlalchemy.orm.exc.NoResultFoundException. With this, if .one() function fails because no result was found, the exception is raised and abort(404) is executed. If another exception is raised, it should be intercepted by Flask, which will then display the 500 error page.

Note that it's not mandatory to "return" before the abort() function, as mentioned here http://flask.pocoo.org/docs/quickstart/#redirects-and-errors .

Do you see anything else to improve this a little bit more?

Thanks !
